### PR TITLE
refactor(web): 视图静态化，移除 Thymeleaf 依赖

### DIFF
--- a/soloncode-cli/pom.xml
+++ b/soloncode-cli/pom.xml
@@ -45,11 +45,6 @@
 
         <dependency>
             <groupId>org.noear</groupId>
-            <artifactId>solon-view-thymeleaf</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.noear</groupId>
             <artifactId>solon-web-staticfiles</artifactId>
         </dependency>
 

--- a/soloncode-cli/src/main/java/org/noear/solon/codecli/portal/WebController.java
+++ b/soloncode-cli/src/main/java/org/noear/solon/codecli/portal/WebController.java
@@ -43,7 +43,6 @@ import org.noear.solon.codecli.provider.ModelProvider;
 import org.noear.solon.codecli.provider.ModelProviderFactory;
 import org.noear.solon.codecli.command.builtin.LoopScheduler;
 import org.noear.solon.core.handle.Context;
-import org.noear.solon.core.handle.ModelAndView;
 import org.noear.solon.core.handle.Result;
 import org.noear.solon.core.handle.UploadedFile;
 import org.noear.solon.core.util.Assert;
@@ -186,21 +185,26 @@ public class WebController {
     }
 
     /**
-     * 对话主界面
-     *
-     * @return
-     * @author oisin
-     * @date 2026年3月14日
+     * 入口：重定向到静态首页 index.html。
      */
     @Get
     @Mapping("/")
-    public ModelAndView chat() {
-        ModelAndView mv = new ModelAndView("chat.html");
-        mv.put("appTitle", Solon.cfg().appTitle());
-        mv.put("appVersion", AgentFlags.getVersion());
-        mv.put("workspace", engine.getProps().getWorkspace());
-        mv.put("workname", getLastSegment(engine.getProps().getWorkspace()));
-        return mv;
+    public void index(Context ctx) throws Throwable {
+        ctx.redirect("/index.html");
+    }
+
+    /**
+     * 页面元信息：由静态首页（/index.html）启动时 fetch 一次，用于回填标题与侧栏。
+     */
+    @Get
+    @Mapping("/chat/meta")
+    public Result<Map> meta() {
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("appTitle", Solon.cfg().appTitle());
+        data.put("appVersion", AgentFlags.getVersion());
+        data.put("workspace", engine.getProps().getWorkspace());
+        data.put("workname", getLastSegment(engine.getProps().getWorkspace()));
+        return Result.succeed(data);
     }
 
     private static String getLastSegment(String pathStr) {

--- a/soloncode-cli/src/main/resources/static/index.html
+++ b/soloncode-cli/src/main/resources/static/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" lang="zh-CN">
+<html lang="zh-CN">
 <head>
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <title th:text="${workname} + ' - ' + ${workspace}">Solon Code Web</title>
+    <title>Solon Code Web</title>
     <link rel="stylesheet" href="/layui/css/layui.css"/>
     <link rel="stylesheet" href="/css/theme.css"/>
     <style>
@@ -338,7 +338,7 @@
         <div class="sidebar-list" id="historyList"></div>
         <div class="sidebar-footer">
             <i class="layui-icon layui-icon-about" style="font-size:15px;color:var(--text-secondary)"></i>
-            <span style="font-size:12px;color:var(--text-secondary)" th:text="${appVersion}">AI</span>
+            <span id="appVersionLabel" style="font-size:12px;color:var(--text-secondary)">AI</span>
         </div>
     </div>
     <button class="sidebar-toggle-btn" id="sidebarToggleBtn" title="收起侧边栏">‹</button>
@@ -357,7 +357,7 @@
                 <div class="blob blob-outer"></div>
                 <div class="blob-core"></div>
             </div>
-            <div class="welcome-title" th:text="'你好，我是 ' + ${appTitle} + ' Web ！'">你好，我是 SolonCode Web ！</div>
+            <div class="welcome-title" id="welcomeTitle">你好，我是 SolonCode Web ！</div>
             <div class="welcome-sub">有什么我可以帮你的吗?</div>
             <div class="welcome-input-box">
                 <div class="attachments-wrap" id="welcomeAttachmentsWrap"></div>
@@ -454,8 +454,20 @@
     <script src="/layui/layui.js"></script>
     <script src="/js/marked.min.js"></script>
 
-    <script th:inline="javascript">
+    <script>
         var SSE_ENDPOINT = "/chat/input";
+        // 启动时拉取页面元信息（appTitle / appVersion / workspace / workname），回填标题/侧栏
+        fetch('/chat/meta').then(function (r) { return r.json(); }).then(function (res) {
+            var meta = (res && res.data) ? res.data : res;
+            if (!meta) return;
+            if (meta.workname || meta.workspace) {
+                document.title = (meta.workname || '') + ' - ' + (meta.workspace || '');
+            }
+            var verEl = document.getElementById('appVersionLabel');
+            if (verEl && meta.appVersion) verEl.textContent = meta.appVersion;
+            var titleEl = document.getElementById('welcomeTitle');
+            if (titleEl && meta.appTitle) titleEl.textContent = '你好，我是 ' + meta.appTitle + ' Web ！';
+        }).catch(function () { /* ignore */ });
     </script>
 
     <script>


### PR DESCRIPTION
- chat.html 移至 static/index.html，去掉 xmlns:th 与所有 th:text 占位
- 前端启动时 fetch /chat/meta 回填 title / 欢迎语 / 版本号
- WebController.chat() 替换为 GET /chat/meta（JSON）+ GET / 302 重定向到 /index.html
- 移除 solon-view-thymeleaf 依赖