### PR TITLE
fix: 保持 Cron 首次执行选项禁用

### DIFF
--- a/soloncode-cli/src/main/resources/static/js/app-loop.js
+++ b/soloncode-cli/src/main/resources/static/js/app-loop.js
@@ -577,6 +577,7 @@
                     showToast('未找到任务数据', 'error');
                 }
                 $p.find('.loop-input, .loop-checkbox input, select').prop('disabled', false);
+                $p.find('input[name=loopScheduleType]:checked').trigger('change');
                 $p.find('#loopFormSaveBtn').prop('disabled', false).text('保存');
             });
         }


### PR DESCRIPTION
触发方式：
1. 新建循环任务（定时心跳）
2. 选择Cron表达式并输入表达式
3. 保存
4. 点击新增的任务右侧的编辑按钮
5. 可以看到第一行的那个固定间隔的时候才能点击的的复选框未被禁用

<img width="1658" height="740" alt="image" src="https://github.com/user-attachments/assets/44f48572-904f-41cc-a4c4-8fbedd20b1b3" />
